### PR TITLE
Add Bepinex plugin interface

### DIFF
--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -1,0 +1,7 @@
+﻿using BepInEx;
+
+namespace Fisobs
+{
+    [BepInPlugin("fisobs", "Fisobs", "4.0.5")]
+    public class Plugin : BaseUnityPlugin {}
+}


### PR DESCRIPTION
Adds an interface for Bepinex,
This fixes an issue with the MultiFolderLoader loading the wrong DLL. ("plugins/fisobs.dll" instead of "newest/plugins/fisobs.dll")
There is a bug in the BepInEx MultiFolderLoader where assemblies that do not have a Bepinex interface get searched for from the root mod directory when being resolved, and the first one that matches gets loaded.