### PR TITLE
CentiShields - BeastMaster support & swallow object example

### DIFF
--- a/examples/centipede-shields/Plugin.cs
+++ b/examples/centipede-shields/Plugin.cs
@@ -21,6 +21,12 @@ sealed class Plugin : BaseUnityPlugin
 
         // Protect the player from grabs while holding a shield
         On.Creature.Grab += CreatureGrab;
+
+        // Allow BeastMaster to spawn CentiShields
+        On.AbstractPhysicalObject.Realize += AbstractPhysicalObjectRealize;
+
+        // Allow swallowing object, uncomment to allow players to swallow CentiShields
+        //On.Player.CanBeSwallowed += PlayerCanBeSwallowed;
     }
 
     void RoomAddObject(On.Room.orig_AddObject orig, Room self, UpdatableAndDeletable obj)
@@ -58,5 +64,30 @@ sealed class Plugin : BaseUnityPlugin
         }
 
         return orig(self, obj, _, _2, _3, dominance, _4, _5);
+    }
+
+    void AbstractPhysicalObjectRealize(On.AbstractPhysicalObject.orig_Realize orig, AbstractPhysicalObject self)
+    {
+        if (self.realizedObject == null && self.type == CentiShieldFisob.CentiShield && self is not CentiShieldAbstract) {
+            CentiShieldAbstract result = new CentiShieldAbstract(self.world, self.pos, self.ID);
+            result.hue = 0f;
+            result.saturation = 1f;
+            result.scaleX = 1.2f;
+            result.scaleY = 1.2f;
+            result.damage = 0f;
+            self.realizedObject = new CentiShield(result, self.pos.Tile.ToVector2(), new Vector2());
+        }
+
+        orig(self);
+    }
+
+    bool PlayerCanBeSwallowed(On.Player.orig_CanBeSwallowed orig, Player self, PhysicalObject testObj)
+    {
+        bool ret = orig(self, testObj);
+
+        if (testObj is CentiShield)
+            ret |= true;
+
+        return ret;
     }
 }

--- a/examples/centipede-shields/Plugin.cs
+++ b/examples/centipede-shields/Plugin.cs
@@ -84,10 +84,7 @@ sealed class Plugin : BaseUnityPlugin
     bool PlayerCanBeSwallowed(On.Player.orig_CanBeSwallowed orig, Player self, PhysicalObject testObj)
     {
         bool ret = orig(self, testObj);
-
-        if (testObj is CentiShield)
-            ret |= true;
-
+        ret |= testObj is CentiShield;
         return ret;
     }
 }


### PR DESCRIPTION
This pull-request adds two new hooks to CentiShields. 
- The AbstractPhysicalObjectRealize hook allows the BeastMaster mod to properly spawn CentiShields. 
- The PlayerCanBeSwallowed hook (currently disabled) allows devs to easily allow players to swallow CentiShields. 

These are some of the things I encountered while creating the Pokéball mod. All changes are added to a separate branch to allow easier modifications before merging. 

Questions or criticism are welcome!